### PR TITLE
Updated games.yml ; Added Melonbooks and Toranoana

### DIFF
--- a/_data/games.yml
+++ b/_data/games.yml
@@ -2,122 +2,173 @@
   steam: https://store.steampowered.com/app/1100140/Touhou_Fuujinroku__Mountain_of_Faith/
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016202
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000000159
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31924
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040010131653/
 
 - title: Touhou Chireiden ~ Subterranean Animism (Touhou 11)
   steam: https://store.steampowered.com/app/1100150/Touhou_Chireiden__Subterranean_Animism/
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016203
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000000197
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31940
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040010159091/
 
 - title: Touhou Seirensen ~ Undefined Fantastic Object (Touhou 12)
   steam: https://store.steampowered.com/app/1100160/Touhou_Seirensen__Undefined_Fantastic_Object/
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016204
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000051946
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31951
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040010193078/
 
 - title: Touhou Shinreibyou ~ Ten Desires (Touhou 13)
   steam: https://store.steampowered.com/app/1043230/Touhou_Shinreibyou__Ten_Desires/
   dlsite: https://www.dlsite.com/home/work/=/product_id/RJ254840.html
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016207
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000000258
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=32140
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040010265966/
 
 - title: Touhou Kishinjou ~ Double Dealing Character (Touhou 14)
   steam: https://store.steampowered.com/app/1043240/Touhou_Kishinjou__Double_Dealing_Character/
   dlsite: https://www.dlsite.com/home/work/=/product_id/RJ254841.html
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016208
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000014552
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=32677
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040030138531/
 
 - title: Touhou Kanjuden ~ Legacy of Lunatic Kingdom (Touhou 15)
   steam: https://store.steampowered.com/app/937580/Touhou_Kanjuden__Legacy_of_Lunatic_Kingdom/
   dlsite: https://www.dlsite.com/home/work/=/product_id/RJ254843.html
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016210
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000052714
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=133259
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040030327982/
 
 - title: Touhou Tenkuushou ~ Hidden Star in Four Seasons (Touhou 16)
   steam: https://store.steampowered.com/app/745880/Touhou_Tenkuushou__Hidden_Star_in_Four_Seasons/
   dlsite: https://www.dlsite.com/home/work/=/product_id/RJ254844.html
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0018536
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000079636
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=227497
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040030552784/
 
 - title: Touhou Kikeijuu ~ Wily Beast and Weakest Creature (Touhou 17)
   steam: https://store.steampowered.com/app/1079160/Touhou_Kikeijuu__Wily_Beast_and_Weakest_Creature/
   dlsite: https://www.dlsite.com/home/work/=/product_id/RJ254866.html
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0022442
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000106516
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=530691
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040030759741/
 
 - title: Touhou Kouryudou ~ Unconnected Marketeers (Touhou 18)
   steam: https://store.steampowered.com/app/1566410/Touhou_Kouryudou__Unconnected_Marketeers/
   dlsite: https://www.dlsite.com/home/work/=/product_id/RJ324742.html
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0025018
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000122295
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=901930
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040030902695/
 
 - title: Touhou Bunkachou ~ Shoot the Bullet (Touhou 9.5)
   steam: https://store.steampowered.com/app/1420650/Touhou_Bunkachou__Shoot_the_Bullet/
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016200
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000000098
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31918
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040000094912/
 
 - title: Double Spoiler ~ Touhou Bunkachou (Touhou 12.5)
   steam: https://store.steampowered.com/app/1100170/Double_Spoiler/
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016205
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000000234
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31982
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040010216561/
 
 - title: Yousei Daisensou ~ Touhou Sangetsusei (Touhou 12.8)
   steam: https://store.steampowered.com/app/1100180/Yousei_Daisensou__Touhou_Sangetsusei/
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016206
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000000241
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31998
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040010230948/
 
 - title: Danmaku Amanojaku ~ Impossible Spell Card (Touhou 14.3)
   steam: https://store.steampowered.com/app/937570/Danmaku_Amanojaku__Impossible_Spell_Card/
   dlsite: https://www.dlsite.com/home/work/=/product_id/RJ254842.html
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016209
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000026227
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=33839
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040030204380/
 
 - title: Touhou Hyouibana ~ Antinomy of Common Flowers (Touhou 15.5)
   steam: https://store.steampowered.com/app/716710/_Antinomy_of_Common_Flowers/
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0019378
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000085842
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=297709
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040030593930/
 
 - title: Hifuu Nightmare Diary ~ Violet Detector (Touhou 16.5)
   steam: https://store.steampowered.com/app/924650/Hifuu_Nightmare_Diary__Violet_Detector/
   dlsite: https://www.dlsite.com/home/work/=/product_id/RJ254845.html
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0020690
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000093885
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=388088
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040030654656/
 
 - title: Touhou Gouyoku Ibun ~ Suibotsushita Chinshuu Jigoku (Touhou 17.5)
   steam: https://store.steampowered.com/app/1440500/_/
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0026149
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000125784
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=1136685
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040030943351/
 
 - title: Touhou Koumakyou ~ the Embodiment of Scarlet Devil (Touhou 6)
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016197
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000000012
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31911
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040000044074/
 
 - title: Touhou Youyoumu ~ Perfect Cherry Blossom (Touhou 7)
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016198
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000000036
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31913
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040000054996/
 
 - title: Touhou Eiyashou ~ Imperishable Night (Touhou 8)
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016199
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000051922
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31915
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040000070319/
 
 - title: Touhou Kaeizuka ~ Phantasmagoria of Flower View (Touhou 9)
+  steam: https://store.steampowered.com/app/1420810/Touhou_Kaeizuka__Phantasmagoria_of_Flower_View/
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016201
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000000081
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31917
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040000087451/
 
 - title: Touhou Suimusou ~ Immaterial and Missing Power (Touhou 7.5)
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016211
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000000067
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31905
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040000075045/
 
 - title: Touhou Hisouten ~ Scarlet Weather Rhapsody (Touhou 10.5)
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016212
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000051939
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31933
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040010148420/
 
 - title: Touhou Hisoutensoku ~ Choudokyuu Ginyoru no Nazo o Oe (Touhou 12.3)
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016213
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000000227
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=31950
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040010190023/
 
 - title: Touhou Shinkirou ~ Hopeless Masquerade (Touhou 13.5)
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016221
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000010028
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=32538
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040030118348/
 
 - title: Touhou Shinpiroku ~ Urban Legend in Limbo (Touhou 14.5)
   amiami: https://www.amiami.com/eng/detail/?gcode=GAME-0016223
   akibahobby: https://shop.akbh.jp/en/collections/vendors/products/2100000048052
+  melonbooks: https://www.melonbooks.co.jp/detail/detail.php?product_id=123901
+  toranoana: https://ecs.toranoana.jp/tora/ec/item/040030298262/


### PR DESCRIPTION
Added links to Melonbooks and Toranoana webpages where Touhou games are sold, as well as the Steam page for Touhou 9.

Melonbooks and Toranoana do not ship internationally and require a proxy/forwarding service.

(Hoping I did this right.)